### PR TITLE
Undefined reference to contentType when contentType is not specified

### DIFF
--- a/src/common/functions.ts
+++ b/src/common/functions.ts
@@ -39,7 +39,7 @@ export function decodeBase64(payload, contentType) {
         result = new Buffer(payload, "base64").toString("utf8");
     }
 
-    if (contentType.indexOf("json") > -1) {
+    if (contentType && contentType.indexOf("json") > -1) {
         result = JSON.parse(result);
     }
 


### PR DESCRIPTION
When calling SDK functions setResourceValue or executeResource, the HTTP PUT and POST responses did not contain a contentType. This undfined contentType variable trickles down into the decodeBase64 function and errors out.

Added a check to verify that contentType even exists before trying to parse out the json data in the response.

Error:
```
    if (contentType.indexOf("json") > -1) {
                   ^

TypeError: Cannot read property 'indexOf' of undefined
    at Object.decodeBase64 (C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\functions.js:42:20)
    at C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\devices\index.js:133:46
    at Array.forEach (native)
    at DevicesApi.notify (C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\devices\index.js:125:37)
    at C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\devices\index.js:152:23
    at C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\apiBase.js:76:17
    at Request.callback (C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\index.js:652:14)
    at C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\index.js:866:18
    at Stream.<anonymous> (C:\Users\micray01\Documents\GitHub\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\parsers\json.js:16:7)
    at emitNone (events.js:86:13)
```