### PR TITLE
Notifications should also fire on devicesAPI object

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -1,4 +1,4 @@
-/* 
+/*
 * mbed Cloud JavaScript SDK
 * Copyright ARM Limited 2017
 *
@@ -135,6 +135,12 @@ export class DevicesApi extends EventEmitter {
                 if (fn) {
                     fn(decodeBase64(notification.payload, notification.ct));
                 }
+
+                this.emit(DevicesApi.EVENT_NOTIFICATION, {
+                    id: notification.ep,
+                    path: notification.path,
+                    payload: decodeBase64(notification.payload, notification.ct)
+                });
             });
         }
 


### PR DESCRIPTION
Notifications should also fire on devicesAPI object, so you can subscribe to all notifications. This is f.e. necessary for presubscriptions.

@thegecko 