### PR TITLE
Check whether async-responses payload is null before decoding

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -170,7 +170,8 @@ export class DevicesApi extends EventEmitter {
                     if (response.status >= 400) {
                         fn(response.error || response.status, null);
                     } else {
-                        fn(null, decodeBase64(response.payload, response.ct));
+                        var body = response.payload ? decodeBase64(response.payload, response.ct) : null;
+                        fn(null, body);
                     }
                     delete this._asyncFns[asyncID];
                 }


### PR DESCRIPTION
I've seen payload and ct be 'undefined' right after restarting a device. This causes 'undefined' being passed into the base64decode function, which throws and thus crashes the whole node process.

@thegecko 