### PR TITLE
data can be null in notify() handler

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -127,6 +127,10 @@ export class DevicesApi extends EventEmitter {
             return device;
         }
 
+        if (!data) {
+            return;
+        }
+
         if (data["notifications"]) {
             data["notifications"].forEach(notification => {
                 var path = notification.ep + notification.path;


### PR DESCRIPTION
Causing the application to crash.

```
/Users/janjon01/repos/konekuta/node_modules/mbed-cloud-sdk/lib/devices/index.js:101
        if (data["notifications"]) {
                ^

TypeError: Cannot read property 'notifications' of null
```