### PR TITLE
Fix for when an account does not have assigned policies

### DIFF
--- a/src/accountManagement/models/accountAdapter.ts
+++ b/src/accountManagement/models/accountAdapter.ts
@@ -30,9 +30,9 @@ import { PolicyAdapter } from "./policyAdapter";
 export class AccountAdapter {
     static map(from: apiAccount, api: AccountManagementApi): Account {
 
-        let policies = from.policies.map(policy => {
+        let policies = from.policies ? from.policies.map(policy => {
             return PolicyAdapter.map(policy);
-        });
+        }) : null;
 
         return new Account({
             //parentId               : from.parent_id,


### PR DESCRIPTION
When an account does not have any policies assigned, updating the account details would fail.

For example, the following code was executed:
```javascript
accountUpdate = {'state': 'Texas'};
accounts.updateAccount(accountUpdate)
.then(data => {
    console.log(data);
})
.catch(error => {
    console.log(error);
});
```

The update would successfully occur, but returning the `Account` object would fail when parsing the policy list. Checking to see if the policy list was `null` before trying to parse the policies is mandatory.

Error log:
```
{ Error: Cannot read property 'map' of null
    at SDKError.Error (native)
    at new SDKError (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\sdkError.js:32:28)
    at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\functions.js:66:26
    at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\apiBase.js:102:17
    at Request.callback (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\index.js:668:14)
    at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\index.js:883:18
    at Stream.<anonymous> (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\parsers\json.js:16:7)
    at emitNone (events.js:86:13)
    at Stream.emit (events.js:185:7)
    at Unzip.<anonymous> (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\unzip.js:53:12)
  innerError:
   TypeError: Cannot read property 'map' of null
       at Function.AccountAdapter.map (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\accountManagement\models\accountAdapter.js:28:37)
       at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\accountManagement\accountManagementApi.js:72:56
       at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\functions.js:62:21
       at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\mbed-cloud-sdk\lib\common\apiBase.js:102:17
       at Request.callback (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\index.js:668:14)
       at C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\index.js:883:18
       at Stream.<anonymous> (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\parsers\json.js:16:7)
       at emitNone (events.js:86:13)
       at Stream.emit (events.js:185:7)
       at Unzip.<anonymous> (C:\cygwin64\home\micray01\cloud\node\mbed-cloud-sdk-javascript-quickstart\node_modules\superagent\lib\node\unzip.js:53:12),
  details: undefined,
  code: undefined }
```
