### PR TITLE
Changed filename to ensure uniqueness

### DIFF
--- a/examples/node/device-events.js
+++ b/examples/node/device-events.js
@@ -45,10 +45,12 @@ function listEvents(after) {
         after: after
     })
     .then(response => {
+
         response.data.forEach(deviceEvent => {
+          var unixTimestamp = new Date(deviceEvent.eventDate).getTime()/1000 | 0;
         	var fileName = path.format({
 				dir: eventDir,
-				base: `${deviceEvent.id}.json`
+				base: `${deviceEvent.id}-${unixTimestamp.toString(16)}.json`
 			});
 
 			var data = JSON.stringify(deviceEvent, null, "\t");


### PR DESCRIPTION
Filename for device-events.js is created based on deviceEvent.id, which the API defines as an optional parameter. To prevent the edge case where Id is not defined, adding a hexidecimal Unix timestamp to the end of the file so that we don't have an undefined.json, and then another overwritten undefined.json.