### PR TITLE
Allow mime type of device resources to be overridden

### DIFF
--- a/src/common/apiBase.ts
+++ b/src/common/apiBase.ts
@@ -19,7 +19,7 @@ import superagent = require("superagent");
 import { SDKError } from "./sdkError";
 
 const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
-const MIME_REGEX = /^application\/json(;.*)?$/i;
+const MIME_REGEX = /^text\/plain(;.*)?$/i;
 
 export class ApiBase {
 

--- a/src/common/apiBase.ts
+++ b/src/common/apiBase.ts
@@ -19,6 +19,7 @@ import superagent = require("superagent");
 import { SDKError } from "./sdkError";
 
 const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+const JSON_REGEX = /^application\/json(;.*)?$/i;
 const MIME_REGEX = /^text\/plain(;.*)?$/i;
 
 export class ApiBase {
@@ -190,7 +191,7 @@ export class ApiBase {
             request.type(requestOptions.contentType);
 
             // Remove empty or undefined json parameters
-            if (body && body.constructor === {}.constructor && MIME_REGEX.test(requestOptions.contentType)) {
+            if (body && body.constructor === {}.constructor && JSON_REGEX.test(requestOptions.contentType)) {
                 body = Object.keys(body).reduce((val, key) => {
                     if (body[key] !== null && body[key] !== undefined) val[key] = body[key];
                     return val;
@@ -242,7 +243,7 @@ export class ApiBase {
             }
 
             // If an object has been returned and we expected json
-            if (data && data.constructor === {}.constructor && MIME_REGEX.test(acceptHeader)) {
+            if (data && data.constructor === {}.constructor && JSON_REGEX.test(acceptHeader)) {
                 data = JSON.parse(JSON.stringify(data), (_key, value) => {
                     // Check for date
                     if (DATE_REGEX.test(value)) return new Date(value);

--- a/src/connect/connectApi.ts
+++ b/src/connect/connectApi.ts
@@ -982,9 +982,10 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param acceptType The requested mime type format of the value
      * @returns Promise of resource value when handling notifications or an asyncId
      */
-    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean): Promise<string | number | { [key: string]: string | number }>;
+    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string): Promise<string | number | { [key: string]: string | number }>;
     /**
      * Gets the value of a resource
      *
@@ -1004,14 +1005,19 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param acceptType The requested mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is the resource value when handling notifications or an asyncId
      */
-    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
-    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: any, noResponse?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
+    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
+    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: any, noResponse?: any, acceptType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
         resourcePath = this.normalizePath(resourcePath);
 
         cacheOnly = cacheOnly || false;
         noResponse = noResponse || false;
+        if (typeof acceptType === "function") {
+            callback = acceptType;
+            acceptType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
@@ -1022,7 +1028,9 @@ export class ConnectApi extends EventEmitter {
         }
 
         return apiWrapper(resultsFn => {
-            this._endpoints.resources.v2EndpointsDeviceIdResourcePathGet(deviceId, resourcePath, cacheOnly, noResponse, resultsFn);
+            this._endpoints.resources.v2EndpointsDeviceIdResourcePathGet(deviceId, resourcePath, cacheOnly, noResponse, resultsFn, {
+                acceptHeader: acceptType
+            });
         }, (data, done) => {
             const asyncID = data[this.ASYNC_KEY];
             if (this.handleNotifications && asyncID) {
@@ -1057,9 +1065,10 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean): Promise<string>;
+    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, contentType?: string): Promise<string>;
     /**
      * Sets the value of a resource
      *
@@ -1080,20 +1089,27 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, callback?: CallbackFn<string>): void;
-    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: any, callback?: CallbackFn<string>): Promise<string> {
+    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
+    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
         resourcePath = this.normalizePath(resourcePath);
 
         noResponse = noResponse || false;
+        if (typeof contentType === "function") {
+            callback = contentType;
+            contentType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
         }
 
         return apiWrapper(resultsFn => {
-            this._endpoints.resources.v2EndpointsDeviceIdResourcePathPut(deviceId, resourcePath, value, noResponse, resultsFn);
+            this._endpoints.resources.v2EndpointsDeviceIdResourcePathPut(deviceId, resourcePath, value, noResponse, resultsFn, {
+                contentType: contentType
+            });
         }, (data, done) => {
             const asyncID = data[this.ASYNC_KEY];
             if (this.handleNotifications && asyncID) {
@@ -1127,9 +1143,10 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean): Promise<string>;
+    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string): Promise<string>;
     /**
      * Execute a function on a resource
      *
@@ -1149,13 +1166,18 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, callback?: CallbackFn<string>): void;
-    public executeResource(deviceId: string, resourcePath: string, functionName?: any, noResponse?: any, callback?: CallbackFn<string>): Promise<string> {
+    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
+    public executeResource(deviceId: string, resourcePath: string, functionName?: any, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
         resourcePath = this.normalizePath(resourcePath);
 
         noResponse = noResponse || false;
+        if (typeof contentType === "function") {
+            callback = contentType;
+            contentType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
@@ -1166,7 +1188,9 @@ export class ConnectApi extends EventEmitter {
         }
 
         return apiWrapper(resultsFn => {
-            this._endpoints.resources.v2EndpointsDeviceIdResourcePathPost(deviceId, resourcePath, functionName, noResponse, resultsFn);
+            this._endpoints.resources.v2EndpointsDeviceIdResourcePathPost(deviceId, resourcePath, functionName, noResponse, resultsFn, {
+                contentType: contentType
+            });
         }, (data, done) => {
             const asyncID = data[this.ASYNC_KEY];
             if (this.handleNotifications && asyncID) {

--- a/src/connect/connectApi.ts
+++ b/src/connect/connectApi.ts
@@ -982,10 +982,10 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param acceptType The requested mime type format of the value
+     * @param mimeType The requested mime type format of the value
      * @returns Promise of resource value when handling notifications or an asyncId
      */
-    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string): Promise<string | number | { [key: string]: string | number }>;
+    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, mimeType?: string): Promise<string | number | { [key: string]: string | number }>;
     /**
      * Gets the value of a resource
      *
@@ -1005,18 +1005,18 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param acceptType The requested mime type format of the value
+     * @param mimeType The requested mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is the resource value when handling notifications or an asyncId
      */
-    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
-    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: any, noResponse?: any, acceptType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
+    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
+    public getResourceValue(deviceId: string, resourcePath: string, cacheOnly?: any, noResponse?: any, mimeType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
         resourcePath = this.normalizePath(resourcePath);
 
         cacheOnly = cacheOnly || false;
         noResponse = noResponse || false;
-        if (typeof acceptType === "function") {
-            callback = acceptType;
-            acceptType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -1029,7 +1029,7 @@ export class ConnectApi extends EventEmitter {
 
         return apiWrapper(resultsFn => {
             this._endpoints.resources.v2EndpointsDeviceIdResourcePathGet(deviceId, resourcePath, cacheOnly, noResponse, resultsFn, {
-                acceptHeader: acceptType
+                acceptHeader: mimeType
             });
         }, (data, done) => {
             const asyncID = data[this.ASYNC_KEY];
@@ -1065,10 +1065,10 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, contentType?: string): Promise<string>;
+    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, mimeType?: string): Promise<string>;
     /**
      * Sets the value of a resource
      *
@@ -1089,17 +1089,17 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
-    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
+    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string>): void;
+    public setResourceValue(deviceId: string, resourcePath: string, value: string, noResponse?: any, mimeType?: any, callback?: CallbackFn<string>): Promise<string> {
         resourcePath = this.normalizePath(resourcePath);
 
         noResponse = noResponse || false;
-        if (typeof contentType === "function") {
-            callback = contentType;
-            contentType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -1108,7 +1108,7 @@ export class ConnectApi extends EventEmitter {
 
         return apiWrapper(resultsFn => {
             this._endpoints.resources.v2EndpointsDeviceIdResourcePathPut(deviceId, resourcePath, value, noResponse, resultsFn, {
-                contentType: contentType
+                contentType: mimeType
             });
         }, (data, done) => {
             const asyncID = data[this.ASYNC_KEY];
@@ -1143,10 +1143,10 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string): Promise<string>;
+    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, mimeType?: string): Promise<string>;
     /**
      * Execute a function on a resource
      *
@@ -1166,17 +1166,17 @@ export class ConnectApi extends EventEmitter {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
-    public executeResource(deviceId: string, resourcePath: string, functionName?: any, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
+    public executeResource(deviceId: string, resourcePath: string, functionName?: string, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string>): void;
+    public executeResource(deviceId: string, resourcePath: string, functionName?: any, noResponse?: any, mimeType?: any, callback?: CallbackFn<string>): Promise<string> {
         resourcePath = this.normalizePath(resourcePath);
 
         noResponse = noResponse || false;
-        if (typeof contentType === "function") {
-            callback = contentType;
-            contentType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -1189,7 +1189,7 @@ export class ConnectApi extends EventEmitter {
 
         return apiWrapper(resultsFn => {
             this._endpoints.resources.v2EndpointsDeviceIdResourcePathPost(deviceId, resourcePath, functionName, noResponse, resultsFn, {
-                contentType: contentType
+                contentType: mimeType
             });
         }, (data, done) => {
             const asyncID = data[this.ASYNC_KEY];

--- a/src/connect/models/connectedDevice.ts
+++ b/src/connect/models/connectedDevice.ts
@@ -111,9 +111,10 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param acceptType The requested mime type format of the value
      * @returns Promise of resource value when handling notifications or an asyncId
      */
-    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean): Promise<string | number | { [key: string]: string | number }>;
+    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string): Promise<string | number | { [key: string]: string | number }>;
     /**
      * Gets the value of a resource
      *
@@ -121,12 +122,17 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param acceptType The requested mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is the resource value when handling notifications or an asyncId
      */
-    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
-    public getResourceValue(resourcePath: string, cacheOnly?: any, noResponse?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
+    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
+    public getResourceValue(resourcePath: string, cacheOnly?: any, noResponse?: any, acceptType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
         cacheOnly = cacheOnly || false;
         noResponse = noResponse || false;
+        if (typeof acceptType === "function") {
+            callback = acceptType;
+            acceptType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
@@ -137,7 +143,7 @@ export class ConnectedDevice extends Device {
         }
 
         return asyncStyle(done => {
-            this._connectApi.getResourceValue(this.id, resourcePath, cacheOnly, noResponse, done);
+            this._connectApi.getResourceValue(this.id, resourcePath, cacheOnly, noResponse, acceptType, done);
         }, callback);
     }
 
@@ -148,9 +154,10 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean): Promise<string>;
+    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, contentType?: string): Promise<string>;
     /**
      * Sets the value of a resource
      *
@@ -158,18 +165,23 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, callback?: CallbackFn<string>): void;
-    public setResourceValue(resourcePath: string, value: string, noResponse?: any, callback?: CallbackFn<string>): Promise<string> {
+    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
+    public setResourceValue(resourcePath: string, value: string, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
+        if (typeof contentType === "function") {
+            callback = contentType;
+            contentType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
         }
 
         return asyncStyle(done => {
-            this._connectApi.setResourceValue(this.id, resourcePath, value, noResponse, done);
+            this._connectApi.setResourceValue(this.id, resourcePath, value, noResponse, contentType, done);
         }, callback);
     }
 
@@ -180,9 +192,10 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean): Promise<string>;
+    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string): Promise<string>;
     /**
      * Execute a function on a resource
      *
@@ -190,11 +203,16 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, callback?: CallbackFn<string>): void;
-    public executeResource(resourcePath: string, functionName?: any, noResponse?: any, callback?: CallbackFn<string>): Promise<string> {
+    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
+    public executeResource(resourcePath: string, functionName?: any, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
+        if (typeof contentType === "function") {
+            callback = contentType;
+            contentType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
@@ -205,7 +223,7 @@ export class ConnectedDevice extends Device {
         }
 
         return asyncStyle(done => {
-            this._connectApi.executeResource(this.id, resourcePath, functionName, noResponse, done);
+            this._connectApi.executeResource(this.id, resourcePath, functionName, noResponse, contentType, done);
         }, callback);
     }
 

--- a/src/connect/models/connectedDevice.ts
+++ b/src/connect/models/connectedDevice.ts
@@ -111,10 +111,10 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param acceptType The requested mime type format of the value
+     * @param mimeType The requested mime type format of the value
      * @returns Promise of resource value when handling notifications or an asyncId
      */
-    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string): Promise<string | number | { [key: string]: string | number }>;
+    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, mimeType?: string): Promise<string | number | { [key: string]: string | number }>;
     /**
      * Gets the value of a resource
      *
@@ -122,16 +122,16 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param acceptType The requested mime type format of the value
+     * @param mimeType The requested mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is the resource value when handling notifications or an asyncId
      */
-    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, acceptType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
-    public getResourceValue(resourcePath: string, cacheOnly?: any, noResponse?: any, acceptType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
+    public getResourceValue(resourcePath: string, cacheOnly?: boolean, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
+    public getResourceValue(resourcePath: string, cacheOnly?: any, noResponse?: any, mimeType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
         cacheOnly = cacheOnly || false;
         noResponse = noResponse || false;
-        if (typeof acceptType === "function") {
-            callback = acceptType;
-            acceptType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -143,7 +143,7 @@ export class ConnectedDevice extends Device {
         }
 
         return asyncStyle(done => {
-            this._connectApi.getResourceValue(this.id, resourcePath, cacheOnly, noResponse, acceptType, done);
+            this._connectApi.getResourceValue(this.id, resourcePath, cacheOnly, noResponse, mimeType, done);
         }, callback);
     }
 
@@ -154,10 +154,10 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, contentType?: string): Promise<string>;
+    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, mimeType?: string): Promise<string>;
     /**
      * Sets the value of a resource
      *
@@ -165,15 +165,15 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
-    public setResourceValue(resourcePath: string, value: string, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
+    public setResourceValue(resourcePath: string, value: string, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string>): void;
+    public setResourceValue(resourcePath: string, value: string, noResponse?: any, mimeType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
-        if (typeof contentType === "function") {
-            callback = contentType;
-            contentType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -181,7 +181,7 @@ export class ConnectedDevice extends Device {
         }
 
         return asyncStyle(done => {
-            this._connectApi.setResourceValue(this.id, resourcePath, value, noResponse, contentType, done);
+            this._connectApi.setResourceValue(this.id, resourcePath, value, noResponse, mimeType, done);
         }, callback);
     }
 
@@ -192,10 +192,10 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string): Promise<string>;
+    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, mimeType?: string): Promise<string>;
     /**
      * Execute a function on a resource
      *
@@ -203,15 +203,15 @@ export class ConnectedDevice extends Device {
      * @param resourcePath Resource path
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
-    public executeResource(resourcePath: string, functionName?: any, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
+    public executeResource(resourcePath: string, functionName?: string, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string>): void;
+    public executeResource(resourcePath: string, functionName?: any, noResponse?: any, mimeType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
-        if (typeof contentType === "function") {
-            callback = contentType;
-            contentType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -223,7 +223,7 @@ export class ConnectedDevice extends Device {
         }
 
         return asyncStyle(done => {
-            this._connectApi.executeResource(this.id, resourcePath, functionName, noResponse, contentType, done);
+            this._connectApi.executeResource(this.id, resourcePath, functionName, noResponse, mimeType, done);
         }, callback);
     }
 

--- a/src/connect/models/resource.ts
+++ b/src/connect/models/resource.ts
@@ -130,26 +130,26 @@ export class Resource extends EventEmitter {
      * __Note:__ This method requires a notification channel to be set up
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param acceptType The requested mime type format of the value
+     * @param mimeType The requested mime type format of the value
      * @returns Promise of resource value when handling notifications or an asyncId
      */
-    public getValue(cacheOnly?: boolean, noResponse?: boolean, acceptType?: string): Promise<string | number | { [key: string]: string | number }>;
+    public getValue(cacheOnly?: boolean, noResponse?: boolean, mimeType?: string): Promise<string | number | { [key: string]: string | number }>;
     /**
      * Gets the value of a resource
      *
      * __Note:__ This method requires a notification channel to be set up
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param acceptType The requested mime type format of the value
+     * @param mimeType The requested mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is the resource value when handling notifications or an asyncId
      */
-    public getValue(cacheOnly?: boolean, noResponse?: boolean, acceptType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
-    public getValue(cacheOnly?: any, noResponse?: any, acceptType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
+    public getValue(cacheOnly?: boolean, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
+    public getValue(cacheOnly?: any, noResponse?: any, mimeType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
         cacheOnly = cacheOnly || false;
         noResponse = noResponse || false;
-        if (typeof acceptType === "function") {
-            callback = acceptType;
-            acceptType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -161,7 +161,7 @@ export class Resource extends EventEmitter {
         }
 
         return asyncStyle(done => {
-            this._api.getResourceValue(this.deviceId, this.path, cacheOnly, noResponse, acceptType, done);
+            this._api.getResourceValue(this.deviceId, this.path, cacheOnly, noResponse, mimeType, done);
         }, callback);
     }
 
@@ -171,25 +171,25 @@ export class Resource extends EventEmitter {
      * __Note:__ This method requires a notification channel to be set up
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public setValue(value: string, noResponse?: boolean, contentType?: string): Promise<string>;
+    public setValue(value: string, noResponse?: boolean, mimeType?: string): Promise<string>;
     /**
      * Sets the value of a resource
      *
      * __Note:__ This method requires a notification channel to be set up
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public setValue(value: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
-    public setValue(value: string, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
+    public setValue(value: string, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string>): void;
+    public setValue(value: string, noResponse?: any, mimeType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
-        if (typeof contentType === "function") {
-            callback = contentType;
-            contentType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -197,7 +197,7 @@ export class Resource extends EventEmitter {
         }
 
         return asyncStyle(done => {
-            this._api.setResourceValue(this.deviceId, this.path, value, noResponse, contentType, done);
+            this._api.setResourceValue(this.deviceId, this.path, value, noResponse, mimeType, done);
         }, callback);
     }
 
@@ -207,25 +207,25 @@ export class Resource extends EventEmitter {
      * __Note:__ This method requires a notification channel to be set up
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public execute(functionName?: string, noResponse?: boolean, contentType?: string): Promise<string>;
+    public execute(functionName?: string, noResponse?: boolean, mimeType?: string): Promise<string>;
     /**
      * Execute a function on a resource
      *
      * __Note:__ This method requires a notification channel to be set up
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
-     * @param contentType The mime type format of the value
+     * @param mimeType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public execute(functionName?: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
-    public execute(functionName?: any, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
+    public execute(functionName?: string, noResponse?: boolean, mimeType?: string, callback?: CallbackFn<string>): void;
+    public execute(functionName?: any, noResponse?: any, mimeType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
-        if (typeof contentType === "function") {
-            callback = contentType;
-            contentType = null;
+        if (typeof mimeType === "function") {
+            callback = mimeType;
+            mimeType = null;
         }
         if (typeof noResponse === "function") {
             callback = noResponse;
@@ -237,7 +237,7 @@ export class Resource extends EventEmitter {
         }
 
         return asyncStyle(done => {
-            this._api.executeResource(this.deviceId, this.path, functionName, noResponse, contentType, done);
+            this._api.executeResource(this.deviceId, this.path, functionName, noResponse, mimeType, done);
         }, callback);
     }
 

--- a/src/connect/models/resource.ts
+++ b/src/connect/models/resource.ts
@@ -130,21 +130,27 @@ export class Resource extends EventEmitter {
      * __Note:__ This method requires a notification channel to be set up
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param acceptType The requested mime type format of the value
      * @returns Promise of resource value when handling notifications or an asyncId
      */
-    public getValue(cacheOnly?: boolean, noResponse?: boolean): Promise<string | number | { [key: string]: string | number }>;
+    public getValue(cacheOnly?: boolean, noResponse?: boolean, acceptType?: string): Promise<string | number | { [key: string]: string | number }>;
     /**
      * Gets the value of a resource
      *
      * __Note:__ This method requires a notification channel to be set up
      * @param cacheOnly If true, the response will come only from the cache
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param acceptType The requested mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is the resource value when handling notifications or an asyncId
      */
-    public getValue(cacheOnly?: boolean, noResponse?: boolean, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
-    public getValue(cacheOnly?: any, noResponse?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
+    public getValue(cacheOnly?: boolean, noResponse?: boolean, acceptType?: string, callback?: CallbackFn<string | number | { [key: string]: string | number }>): void;
+    public getValue(cacheOnly?: any, noResponse?: any, acceptType?: any, callback?: CallbackFn<string | number | { [key: string]: string | number }>): Promise<string | number | { [key: string]: string | number }> {
         cacheOnly = cacheOnly || false;
         noResponse = noResponse || false;
+        if (typeof acceptType === "function") {
+            callback = acceptType;
+            acceptType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
@@ -155,7 +161,7 @@ export class Resource extends EventEmitter {
         }
 
         return asyncStyle(done => {
-            this._api.getResourceValue(this.deviceId, this.path, cacheOnly, noResponse, done);
+            this._api.getResourceValue(this.deviceId, this.path, cacheOnly, noResponse, acceptType, done);
         }, callback);
     }
 
@@ -165,27 +171,33 @@ export class Resource extends EventEmitter {
      * __Note:__ This method requires a notification channel to be set up
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public setValue(value: string, noResponse?: boolean): Promise<string>;
+    public setValue(value: string, noResponse?: boolean, contentType?: string): Promise<string>;
     /**
      * Sets the value of a resource
      *
      * __Note:__ This method requires a notification channel to be set up
      * @param value The value of the resource
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public setValue(value: string, noResponse?: boolean, callback?: CallbackFn<string>): void;
-    public setValue(value: string, noResponse?: any, callback?: CallbackFn<string>): Promise<string> {
+    public setValue(value: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
+    public setValue(value: string, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
+        if (typeof contentType === "function") {
+            callback = contentType;
+            contentType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
         }
 
         return asyncStyle(done => {
-            this._api.setResourceValue(this.deviceId, this.path, value, noResponse, done);
+            this._api.setResourceValue(this.deviceId, this.path, value, noResponse, contentType, done);
         }, callback);
     }
 
@@ -195,20 +207,26 @@ export class Resource extends EventEmitter {
      * __Note:__ This method requires a notification channel to be set up
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @returns Promise containing an asyncId when there isn't a notification channel
      */
-    public execute(functionName?: string, noResponse?: boolean): Promise<string>;
+    public execute(functionName?: string, noResponse?: boolean, contentType?: string): Promise<string>;
     /**
      * Execute a function on a resource
      *
      * __Note:__ This method requires a notification channel to be set up
      * @param functionName The function to trigger
      * @param noResponse If true, Mbed Device Connector will not wait for a response
+     * @param contentType The mime type format of the value
      * @param callback A function that is passed the arguments (error, value) where value is an asyncId when there isn't a notification channel
      */
-    public execute(functionName?: string, noResponse?: boolean, callback?: CallbackFn<string>): void;
-    public execute(functionName?: any, noResponse?: any, callback?: CallbackFn<string>): Promise<string> {
+    public execute(functionName?: string, noResponse?: boolean, contentType?: string, callback?: CallbackFn<string>): void;
+    public execute(functionName?: any, noResponse?: any, contentType?: any, callback?: CallbackFn<string>): Promise<string> {
         noResponse = noResponse || false;
+        if (typeof contentType === "function") {
+            callback = contentType;
+            contentType = null;
+        }
         if (typeof noResponse === "function") {
             callback = noResponse;
             noResponse = false;
@@ -219,7 +237,7 @@ export class Resource extends EventEmitter {
         }
 
         return asyncStyle(done => {
-            this._api.executeResource(this.deviceId, this.path, functionName, noResponse, done);
+            this._api.executeResource(this.deviceId, this.path, functionName, noResponse, contentType, done);
         }, callback);
     }
 


### PR DESCRIPTION
This PR also switches to using text/plain as the default resource mime type.