### PR TITLE
⭕️IOTSTOOL-634 Use older version of chrome to fix unit tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,8 @@ dependencies:
   pre:
     - npm install -g npm@latest
     - npm install -g codecov ansi-html-stream
-    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    # - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - curl -L -o google-chrome.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_64.0.3282.186-1_amd64.deb
     - sudo dpkg -i google-chrome.deb
     - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
     - |

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,7 @@ dependencies:
   pre:
     - npm install -g npm@latest
     - npm install -g codecov ansi-html-stream
+    # Version 65.0.3325.146-1 seems to have a bug which breaks the unit tests
     # - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
     - curl -L -o google-chrome.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_64.0.3282.186-1_amd64.deb
     - sudo dpkg -i google-chrome.deb


### PR DESCRIPTION
Current version of chrome (65.0.3325.146-1) seems to have a bug, using an older version (64.0.3282.186-1) resolves the issue.