### PR TITLE
⭕️reinstate build branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,6 +315,7 @@ workflows:
                 - beta
       - create_build_branch_gate:
           <<: *ignore_main_branches
+          type: approval
           requires:
             - build
       - create_build_branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,12 @@ references:
         only:
         - master
         - beta
-        - f/reinstate-build-branches
   ignore_main_branches: &ignore_main_branches
     filters:
       branches:
         ignore:
         - master
         - beta
-        - f/reinstate-build-branches
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,8 @@ jobs:
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
-              git push -f -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
+              git pull origin build/${CIRCLE_BRANCH}
+              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,7 @@ workflows:
           requires:
             - build
       - build_sync:
+          <<: *main_branches_only
           requires:
             - unit_test
             - integration_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ workflows:
       - build_sync:
           requires:
             - unit_test
-            - integration_test
+            # - integration_test
       - beta_release_gate:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
       - build_sync:
           requires:
             - unit_test
-            # - integration_test
+            - integration_test
       - beta_release_gate:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,16 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./
+      - run:
+          name: sync to build branch
+          command: |
+              git add --force lib bundles types package.json
+              git stash save
+              git checkout -b build/${CIRCLE_BRANCH}
+              git merge ${CIRCLE_BRANCH} --no-commit
+              git checkout stash -- .
+              git commit --allow-empty --message "Sync Build [skip ci]"
+              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ references:
         only:
         - master
         - beta
+        - f/reinstate-build-branches
 
 jobs:
   build:
@@ -269,7 +270,7 @@ jobs:
           command: |
               git add --force lib bundles types package.json
               git stash save
-              git checkout build/${CIRCLE_BRANCH}
+              git checkout -b build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
@@ -300,7 +301,7 @@ workflows:
           <<: *main_branches_only
           requires:
             - unit_test
-            - integration_test
+            # - integration_test
       - beta_release_gate:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,11 +271,12 @@ jobs:
               git add --force lib bundles types package.json
               git stash save
               git checkout -B build/${CIRCLE_BRANCH}
-              git push https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git --set-upstream origin build/${CIRCLE_BRANCH}
+              git branch --set-upstream-to=origin/${CIRCLE_BRANCH} build/${CIRCLE_BRANCH}
+              git pull
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
-              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
+              git push -f -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ references:
         only:
         - master
         - beta
-        - f/reinstate-build-branches
 
 jobs:
   build:
@@ -270,11 +269,11 @@ jobs:
           command: |
               git add --force lib bundles types package.json
               git stash save
-              git checkout build-build/${CIRCLE_BRANCH}
+              git checkout build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
-              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build-build/${CIRCLE_BRANCH}
+              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,14 @@
 version: 2
+
+references:
+   main_branches_only: &main_branches_only
+    filters:
+      branches:
+        only:
+        - master
+        - beta
+        - f/reinstate-build-branches
+
 jobs:
   build:
     working_directory: ~/build
@@ -44,6 +54,7 @@ jobs:
             - bundles
             - lib
             - types
+            - package.json
   tpip:
     working_directory: ~/build
     docker:
@@ -247,6 +258,13 @@ jobs:
               curl -X POST --header "Content-Type: application/json" \
                -d '{"branch":"master"}' \
                https://circleci.com/api/v1.1/project/github/${ORGANISATION}/${DOCUMENTATION_PROJECT}/build?circle-token=${CIRCLE_TOKEN}
+  build_sync:
+    docker:
+      - image: circleci/node:jessie-browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
 
 workflows:
   version: 2
@@ -269,6 +287,10 @@ workflows:
       - unit_test:
           requires:
             - build
+      - build_sync:
+          requires:
+            - unit_test
+            - integration_test
       - beta_release_gate:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,8 +270,7 @@ jobs:
           command: |
               git add --force lib bundles types package.json
               git stash save
-              git checkout -b build/${CIRCLE_BRANCH}
-              git pull build/${CIRCLE_BRANCH}
+              git checkout -B build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
@@ -301,7 +300,8 @@ workflows:
       - build_sync:
           <<: *main_branches_only
           requires:
-            - unit_test
+            - build
+            # - unit_test
             # - integration_test
       - beta_release_gate:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
               git add --force lib bundles types package.json
               git stash save
               git checkout -B build/${CIRCLE_BRANCH}
+              git push https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git --set-upstream origin build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,11 +270,11 @@ jobs:
           command: |
               git add --force lib bundles types package.json
               git stash save
-              git checkout build/${CIRCLE_BRANCH}
+              git checkout build-build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
-              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
+              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build-build/${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ jobs:
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
               git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
-  arbitury_build_sync:
+  create_build_branch:
     docker:
       - image: circleci/node:jessie-browsers
     steps:
@@ -288,7 +288,7 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: sync to build branch
+          name: sync to build branch if exists or create new one
           command: |
               git add --force lib bundles types package.json
               git stash save

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
               git add --force lib bundles types package.json
               git stash save
               git checkout -b build/${CIRCLE_BRANCH}
+              git pull build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,17 @@
 version: 2
 
 references:
-   main_branches_only: &main_branches_only
+  main_branches_only: &main_branches_only
     filters:
       branches:
         only:
+        - master
+        - beta
+        - f/reinstate-build-branches
+  ignore_main_branches: &ignore_main_branches
+    filters:
+      branches:
+        ignore:
         - master
         - beta
         - f/reinstate-build-branches
@@ -270,6 +277,23 @@ jobs:
           command: |
               git add --force lib bundles types package.json
               git stash save
+              git checkout build/${CIRCLE_BRANCH}
+              git merge ${CIRCLE_BRANCH} --no-commit
+              git checkout stash -- .
+              git commit --allow-empty --message "Sync Build [skip ci]"
+              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
+  arbitury_build_sync:
+    docker:
+      - image: circleci/node:jessie-browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: sync to build branch
+          command: |
+              git add --force lib bundles types package.json
+              git stash save
               git checkout -B build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
@@ -291,6 +315,14 @@ workflows:
               only:
                 - master
                 - beta
+      - create_build_branch_gate:
+          <<: *ignore_main_branches
+          requires:
+            - build
+      - create_build_branch:
+          <<: *ignore_main_branches
+          requires:
+            - create_build_branch_gate
       - integration_test:
           requires:
             - build
@@ -300,9 +332,8 @@ workflows:
       - build_sync:
           <<: *main_branches_only
           requires:
-            - build
-            # - unit_test
-            # - integration_test
+            - unit_test
+            - integration_test
       - beta_release_gate:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,13 +271,10 @@ jobs:
               git add --force lib bundles types package.json
               git stash save
               git checkout -B build/${CIRCLE_BRANCH}
-              git branch --set-upstream-to=origin/${CIRCLE_BRANCH} build/${CIRCLE_BRANCH}
-              git pull
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"
-              git pull origin build/${CIRCLE_BRANCH}
-              git push -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
+              git push -f -q https://${GITHUB_TOKEN}@github.com/ARMmbed/mbed-cloud-sdk-javascript.git build/${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
           command: |
               git add --force lib bundles types package.json
               git stash save
-              git checkout -b build/${CIRCLE_BRANCH}
+              git checkout build/${CIRCLE_BRANCH}
               git merge ${CIRCLE_BRANCH} --no-commit
               git checkout stash -- .
               git commit --allow-empty --message "Sync Build [skip ci]"


### PR DESCRIPTION
- syncs to build branch for any successful build on mater/beta branches
- might be useful for people wanting to test foundation SDK before release