### PR TITLE
⭕️ 1951 Slack webhook removed from script

### DIFF
--- a/docs/news/1951.misc
+++ b/docs/news/1951.misc
@@ -1,0 +1,1 @@
+Webhook for posting release notifications to Slack have been removed from script.

--- a/scripts/tag_and_release.py
+++ b/scripts/tag_and_release.py
@@ -82,9 +82,17 @@ def release(config_file):
 
 
 def post_to_slack(version):
-    # posting message to slack
-    body = {"text": ":checkered_flag: New version of :javascript: SDK released: {}".format(version)}
-    myurl = "https://hooks.slack.com/services/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"
+    """Post a message to the SDK slack channel.
+    This uses an incoming webhook which is made available by a pre-configured Slack App.
+    """
+    print("Posting a message to Slack")
+    body = {
+        "channel": "#isg-dm-sdk",
+        "username": "SDK Release Announcement",
+        "icon_emoji": ":javascript:",
+        "text": ":checkered_flag: New version of :javascript: SDK released: {}".format(version),
+    }
+    myurl = os.getenv('SLACK_NOTIFICATION_WEBHOOK')
     req = urllib.request.Request(myurl)
     req.add_header('Content-Type', 'application/json; charset=utf-8')
     jsondata = json.dumps(body)
@@ -108,5 +116,7 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == 'beta':
             main('beta')
+        if sys.argv[1] == 'slack':
+            post_to_slack(sys.argv[2])
     else:
         main()


### PR DESCRIPTION
Slack webhook is now stored in a CircleCI environment variable as a security measure.