### PR TITLE
MISC: pass callback as apiKey

### DIFF
--- a/docs/news/2510190928.feature
+++ b/docs/news/2510190928.feature
@@ -1,0 +1,1 @@
+Add option to supply api key as callback, for scenarious when you have a key that needs refreshing

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,4 +1,3 @@
-import { ConnectionOptions } from "../legacy/common/interfaces";
 import * as dotenv from "dotenv";
 import { SDKLogLevel } from "./logger";
 
@@ -10,10 +9,18 @@ export class Config {
     private static readonly ENV_HOST = "MBED_CLOUD_SDK_HOST";
     private static readonly ENV_LOG_LEVEL = "MBED_CLOUD_SDK_LOG_LEVEL";
 
+    private _apiKey: string | (() => string);
+
     /**
      * The Pelion Device Management Api Key
      */
-    public readonly apiKey: string;
+    public get apiKey(): string {
+        if (typeof this._apiKey === "function") {
+            return this.ensureBearer(this._apiKey()) as string;
+        }
+
+        return this._apiKey;
+    }
 
     /**
      * The host, will default to "https://api.us-east-1.mbedcloud.com"
@@ -29,13 +36,35 @@ export class Config {
      * Initalise a new isntance of Config
      * @param options The connection options
      */
-    constructor(options?: ConnectionOptions) {
-        options = options || {};
+    constructor(options?: ConfigOptions) {
+        options = options || {} as Config;
         if (dotenv && typeof dotenv.config === "function") { dotenv.config(); }
-        this.apiKey = options.apiKey || (process && process.env[Config.ENV_API_KEY]) || "default";
+        this._apiKey = this.ensureBearer(options.apiKey || (process && process.env[Config.ENV_API_KEY]) || "default");
         this.host = options.host || (process && process.env[Config.ENV_HOST]) || "https://api.us-east-1.mbedcloud.com";
         this.logLevel = options.logLevel || (process && (process.env[Config.ENV_LOG_LEVEL]) as SDKLogLevel) || "WARN";
-        if (this.apiKey.substr(0, 6).toLowerCase() !== "bearer") { this.apiKey = `Bearer ${this.apiKey}`; }
         if (!this.host.startsWith("https")) this.host = `https://${this.host}`;
     }
+
+    private ensureBearer(key: string | (() => string)): string | (() => string) {
+        if (typeof key === "string" && key.substr(0, 6).toLowerCase() !== "bearer") {
+            return `Bearer ${key}`;
+        }
+
+        return key;
+    }
+}
+
+export interface ConfigOptions {
+    /**
+     * API Key for your Pelion Device Management account
+     */
+    apiKey?: string | (() => string);
+    /**
+     * URL for Pelion Device Management API
+     */
+    host?: string;
+    /**
+    * configure the log level for this api instance
+    */
+    logLevel?: SDKLogLevel;
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -37,7 +37,7 @@ export class Config {
      * @param options The connection options
      */
     constructor(options?: ConfigOptions) {
-        options = options || {} as Config;
+        options = options || {} as ConfigOptions;
         if (dotenv && typeof dotenv.config === "function") { dotenv.config(); }
         this._apiKey = this.ensureBearer(options.apiKey || (process && process.env[Config.ENV_API_KEY]) || "default");
         this.host = options.host || (process && process.env[Config.ENV_HOST]) || "https://api.us-east-1.mbedcloud.com";

--- a/src/common/paginator.ts
+++ b/src/common/paginator.ts
@@ -72,6 +72,10 @@ export class Paginator<T extends Entity, U extends ListOptions> implements Async
         return this._afters;
     }
 
+    public get currentTotalCount(): number {
+        return this._currentPage ? this._currentPage.totalCount : 0;
+    }
+
     /**
      * Create a new instance of a Paginator
      * @param fetchPage the function to fetch each page
@@ -95,7 +99,7 @@ export class Paginator<T extends Entity, U extends ListOptions> implements Async
      */
     public reset(): void {
         this._currentPageIndex = -1;
-        this._currentPage = undefined;
+        this._currentPage = null;
         this._afters = [];
         this.listOptions.after = null;
         this._currentItemIndex = -1;

--- a/src/common/repository.ts
+++ b/src/common/repository.ts
@@ -1,4 +1,4 @@
-import { Config } from "./config";
+import { Config, ConfigOptions } from "./config";
 import { Client } from "../client/client";
 
 /**
@@ -20,7 +20,7 @@ export abstract class Repository {
      * @param config The configuration to use, if null then repository will initalise its own using dotenv
      * @param client The client instance to use
      */
-    constructor(config?: Config, client?: Client) {
+    constructor(config?: ConfigOptions, client?: Client) {
         if (config && config instanceof Config) {
             this.config = config;
         } else {

--- a/src/legacy/accountManagement/accountManagementApi.ts
+++ b/src/legacy/accountManagement/accountManagementApi.ts
@@ -16,7 +16,7 @@
 */
 
 import { asyncStyle, apiWrapper, encodeInclude, extractFilter } from "../common/functions";
-import { ConnectionOptions, CallbackFn, ListOptions } from "../common/interfaces";
+import { CallbackFn, ListOptions } from "../common/interfaces";
 import { ListResponse } from "../common/listResponse";
 import { Endpoints } from "./endpoints";
 import { UpdateAccountObject, AddApiKeyObject, UpdateApiKeyObject, AddUserObject, UpdateUserObject, ApiKeyListOptions, UserListOptions, GroupListOptions } from "./types";
@@ -29,6 +29,7 @@ import { UserAdapter } from "./models/userAdapter";
 import { Group } from "./models/group";
 import { GroupAdapter } from "./models/groupAdapter";
 import { ApiMetadata } from "../common/apiMetadata";
+import { ConfigOptions } from "../../common/config";
 
 /**
  * ## Account Management API
@@ -72,7 +73,7 @@ export class AccountManagementApi {
     /**
      * @param options connection options
      */
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/legacy/accountManagement/endpoints.ts
+++ b/src/legacy/accountManagement/endpoints.ts
@@ -15,19 +15,19 @@
 * limitations under the License.
 */
 
-import { ConnectionOptions } from "../common/interfaces";
 import { EndpointsBase } from "../common/endpointsBase";
 import {
     DeveloperApi,
     AccountAdminApi,
 } from "../_api/iam";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
 
     public developer: DeveloperApi;
     public admin: AccountAdminApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.developer = new DeveloperApi(options, this.responseHandler.bind(this));
         this.admin = new AccountAdminApi(options, this.responseHandler.bind(this));

--- a/src/legacy/billing/billingApi.ts
+++ b/src/legacy/billing/billingApi.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ConnectionOptions, CallbackFn, ListOptions } from "../common/interfaces";
+import { CallbackFn, ListOptions } from "../common/interfaces";
 import { Endpoints } from "./endpoints";
 import { apiWrapper, dateToBillingMonth, isThisNode } from "../common/functions";
 import { QuotaHistory } from "./models/quotaHistory";
@@ -27,6 +27,7 @@ import { mapPending, mapActive, mapPrevious } from "./models/servicePackageAdapt
 import { SDKError } from "../common/sdkError";
 import { writeFile, createWriteStream } from "fs";
 import { get as http_get } from "superagent";
+import { ConfigOptions } from "../../common/config";
 
 export class BillingApi {
     private readonly _endpoints: Endpoints;
@@ -66,7 +67,7 @@ export class BillingApi {
      * ```
      * @param options Connection objects
      */
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/legacy/billing/endpoints.ts
+++ b/src/legacy/billing/endpoints.ts
@@ -17,12 +17,12 @@
 
 import { EndpointsBase } from "../common/endpointsBase";
 import { DefaultApi as BillingApi } from "../_api/billing";
-import { ConnectionOptions } from "../common/interfaces";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
     public readonly billing: BillingApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.billing = new BillingApi(options, this.responseHandler.bind(this));
     }

--- a/src/legacy/bootstrap/bootstrapApi.ts
+++ b/src/legacy/bootstrap/bootstrapApi.ts
@@ -17,12 +17,13 @@
 
 import { apiWrapper, asyncStyle } from "../common/functions";
 import { Endpoints } from "./endpoints";
-import { CallbackFn, ConnectionOptions } from "../common/interfaces";
+import { CallbackFn } from "../common/interfaces";
 import { AddPreSharedKey, PskListOptions } from "./types";
 import { PreSharedKey } from "./models/preSharedKey";
 import { mapToSDK, mapToSpec, mapFrom } from "./models/preSharedKeyAdapter";
 import { ApiMetadata } from "../common/apiMetadata";
 import { ListResponse } from "../common/listResponse";
+import { ConfigOptions } from "../../common/config";
 
 export class BootstrapApi {
     private readonly _endpoints: Endpoints;
@@ -62,7 +63,7 @@ export class BootstrapApi {
      * ```
      * @param options Connection objects
      */
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/legacy/bootstrap/endpoints.ts
+++ b/src/legacy/bootstrap/endpoints.ts
@@ -16,13 +16,13 @@
  */
 
 import { EndpointsBase } from "../common/endpointsBase";
-import { ConnectionOptions } from "../common/interfaces";
 import { PreSharedKeysApi } from "../_api/connector_bootstrap";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
     public readonly bootstrap: PreSharedKeysApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.bootstrap = new PreSharedKeysApi(options, this.responseHandler.bind(this));
     }

--- a/src/legacy/certificates/certificatesApi.ts
+++ b/src/legacy/certificates/certificatesApi.ts
@@ -16,7 +16,7 @@
 */
 
 import { asyncStyle, apiWrapper, encodeInclude, extractFilter } from "../common/functions";
-import { ConnectionOptions, CallbackFn } from "../common/interfaces";
+import { CallbackFn } from "../common/interfaces";
 import { ListResponse } from "../common/listResponse";
 import { TrustedCertificateResp as iamCertificate } from "../_api/iam";
 import { Endpoints } from "./endpoints";
@@ -24,6 +24,7 @@ import { AddDeveloperCertificateObject, AddCertificateObject, UpdateCertificateO
 import { Certificate } from "./models/certificate";
 import { CertificateAdapter } from "./models/certificateAdapter";
 import { ApiMetadata } from "../common/apiMetadata";
+import { ConfigOptions } from "../../common/config";
 
 /**
  * ## Certificates API
@@ -68,7 +69,7 @@ export class CertificatesApi {
     /**
      * @param options connection options
      */
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/legacy/certificates/endpoints.ts
+++ b/src/legacy/certificates/endpoints.ts
@@ -15,13 +15,13 @@
 * limitations under the License.
 */
 
-import { ConnectionOptions } from "../common/interfaces";
 import { EndpointsBase } from "../common/endpointsBase";
 import {
     AccountAdminApi as AdminApi,
     DeveloperApi as AccountDeveloperApi,
 } from "../_api/iam";
 import { DeveloperCertificateApi as ConnectorApi, ServerCredentialsApi } from "../_api/connector_ca";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
 
@@ -30,7 +30,7 @@ export class Endpoints extends EndpointsBase {
     public admin: AdminApi;
     public serverCredentials: ServerCredentialsApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.accountDeveloper = new AccountDeveloperApi(options, this.responseHandler.bind(this));
         this.connector = new ConnectorApi(options, this.responseHandler.bind(this));

--- a/src/legacy/common/apiBase.ts
+++ b/src/legacy/common/apiBase.ts
@@ -20,9 +20,9 @@ import * as superagent from "superagent";
 import * as dotenv from "dotenv";
 
 import { SDKError } from "./sdkError";
-import { ConnectionOptions } from "./interfaces";
 import { Version } from "../../version";
 import { isThisNode } from "./functions";
+import { ConfigOptions } from "../../common/config";
 
 const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
 const JSON_REGEX = /^application\/json(;.*)?$/i;
@@ -41,7 +41,7 @@ export class ApiBase {
     private readonly apiKey;
     private readonly host;
 
-    constructor(options?: ConnectionOptions, private responseHandler: (sdkError: SDKError, response: superagent.Response) => any = null) {
+    constructor(options?: ConfigOptions, private responseHandler: (sdkError: SDKError, response: superagent.Response) => any = null) {
         options = options || {};
         if (dotenv && typeof dotenv.config === "function") { dotenv.config(); }
         this.apiKey = options.apiKey || (process && process.env[this.ENV_API_KEY]);

--- a/src/legacy/common/interfaces.ts
+++ b/src/legacy/common/interfaces.ts
@@ -16,22 +16,6 @@
 */
 
 import { SDKError } from "./sdkError";
-import { SDKLogLevel } from "../../common/logger";
-
-export interface ConnectionOptions {
-    /**
-     * API Key for your Pelion Device Management account
-     */
-    apiKey?: string;
-    /**
-     * URL for Pelion Device Management API
-     */
-    host?: string;
-    /**
-    * configure the log level for this api instance
-    */
-    logLevel?: SDKLogLevel;
-}
 
 export type CallbackFn<T> = (error: SDKError, data?: T) => any;
 

--- a/src/legacy/connect/connectApi.ts
+++ b/src/legacy/connect/connectApi.ts
@@ -42,6 +42,7 @@ import { Subscribe } from "../../primary/subscribe/subscribe";
 import { loggerFactory } from "../../common/logger";
 import { Logger } from "typescript-logging";
 import { isJwt } from "../../common/utils";
+import { Config } from "../..";
 
 /**
  * ## Connect API
@@ -145,7 +146,7 @@ export class ConnectApi extends EventEmitter {
      */
     public readonly handleNotifications?: boolean;
 
-    private _config: ConnectOptions;
+    private _config: Config;
     private _pollRequest: superagent.SuperAgentRequest | boolean;
     // private readonly _websockerUrl: string = "";
     private _instanceId: string;
@@ -173,8 +174,8 @@ export class ConnectApi extends EventEmitter {
      */
     constructor(options?: ConnectOptions) {
         super();
-        options = options || {};
-        this._config = options;
+        options = options || {} as ConnectOptions;
+        this._config = new Config(options);
         this._instanceId = generateId();
         // this._connectOptions = options;
         this._endpoints = new Endpoints(options);

--- a/src/legacy/connect/endpoints.ts
+++ b/src/legacy/connect/endpoints.ts
@@ -15,7 +15,6 @@
 * limitations under the License.
 */
 
-import { ConnectionOptions } from "../common/interfaces";
 import { AccountApi, StatisticsApi } from "../_api/statistics";
 import { EndpointsBase } from "../common/endpointsBase";
 import {
@@ -25,6 +24,7 @@ import {
     ResourcesApi,
     SubscriptionsApi,
 } from "../_api/mds";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
 
@@ -36,7 +36,7 @@ export class Endpoints extends EndpointsBase {
     public account: AccountApi;
     public statistics: StatisticsApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.endpoints = new EndpointsApi(options, this.responseHandler.bind(this));
         this.deviceRequests = new DeviceRequestsApi(options, this.responseHandler.bind(this));

--- a/src/legacy/connect/types.ts
+++ b/src/legacy/connect/types.ts
@@ -15,10 +15,11 @@
 * limitations under the License.
 */
 
-import { CallbackFn, ConnectionOptions, Order } from "../common/interfaces";
+import { CallbackFn, Order } from "../common/interfaces";
 import { TlvValue } from "../../common/tlv";
+import { ConfigOptions } from "../../common/config";
 
-export interface ConnectOptions extends ConnectionOptions {
+export interface ConnectOptions extends ConfigOptions {
     /**
      * @deprecated will detect webhook usage with a call to updateWebhook
      */

--- a/src/legacy/deviceDirectory/deviceDirectoryApi.ts
+++ b/src/legacy/deviceDirectory/deviceDirectoryApi.ts
@@ -16,7 +16,7 @@
 */
 
 import { asyncStyle, apiWrapper, encodeInclude, encodeFilter } from "../common/functions";
-import { ConnectionOptions, CallbackFn } from "../common/interfaces";
+import { CallbackFn } from "../common/interfaces";
 import { ListResponse } from "../common/listResponse";
 import { AddDeviceObject, UpdateDeviceObject, AddQueryObject, UpdateQueryObject, DeviceListOptions, QueryListOptions, DeviceEventListOptions } from "./types";
 import { Device } from "./models/device";
@@ -28,6 +28,7 @@ import { DeviceEventAdapter } from "./models/deviceEventAdapter";
 import { Endpoints } from "./endpoints";
 import { Filters } from "./filters";
 import { ApiMetadata } from "../common/apiMetadata";
+import { ConfigOptions } from "../../common/config";
 
 /**
  * ## Device Directory API
@@ -72,7 +73,7 @@ export class DeviceDirectoryApi {
     /**
      * @param options connection objects
      */
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/legacy/deviceDirectory/endpoints.ts
+++ b/src/legacy/deviceDirectory/endpoints.ts
@@ -15,15 +15,15 @@
 * limitations under the License.
 */
 
-import { ConnectionOptions } from "../common/interfaces";
 import { DefaultApi as DirectoryApi } from "../_api/device_directory";
 import { EndpointsBase } from "../common/endpointsBase";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
 
     public directory: DirectoryApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.directory = new DirectoryApi(options, this.responseHandler.bind(this));
     }

--- a/src/legacy/enrollment/endpoints.ts
+++ b/src/legacy/enrollment/endpoints.ts
@@ -16,13 +16,13 @@
  */
 
 import { EndpointsBase } from "../common/endpointsBase";
-import { ConnectionOptions } from "../common/interfaces";
 import { PublicAPIApi as EnrollmentApi } from "../_api/enrollment";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
     public readonly enrollment: EnrollmentApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.enrollment = new EnrollmentApi(options, this.responseHandler.bind(this));
     }

--- a/src/legacy/enrollment/enrollmentApi.ts
+++ b/src/legacy/enrollment/enrollmentApi.ts
@@ -17,12 +17,13 @@
 
 import { apiWrapper, encodeInclude, asyncStyle } from "../common/functions";
 import { Endpoints } from "./endpoints";
-import { CallbackFn, ConnectionOptions, ListOptions } from "../common/interfaces";
+import { CallbackFn, ListOptions } from "../common/interfaces";
 import { AddEnrollmentClaim } from "./types";
 import { EnrollmentClaim } from "./models/enrollmentClaim";
 import { ListResponse } from "../common/listResponse";
 import * as EnrollmentAdapter from "./models/enrollmentClaimAdapter";
 import { ApiMetadata } from "../common/apiMetadata";
+import { ConfigOptions } from "../../common/config";
 
 export class EnrollmentApi {
     private readonly _endpoints: Endpoints;
@@ -63,7 +64,7 @@ export class EnrollmentApi {
      * ```
      * @param options Connection objects
      */
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/legacy/update/endpoints.ts
+++ b/src/legacy/update/endpoints.ts
@@ -15,15 +15,15 @@
 * limitations under the License.
 */
 
-import { ConnectionOptions } from "../common/interfaces";
 import { DefaultApi as UpdateApi } from "../_api/update_service";
 import { EndpointsBase } from "../common/endpointsBase";
+import { ConfigOptions } from "../../common/config";
 
 export class Endpoints extends EndpointsBase {
 
     public update: UpdateApi;
 
-    constructor(options?: ConnectionOptions) {
+    constructor(options?: ConfigOptions) {
         super();
         this.update = new UpdateApi(options, this.responseHandler.bind(this));
     }

--- a/src/legacy/update/updateApi.ts
+++ b/src/legacy/update/updateApi.ts
@@ -16,7 +16,7 @@
 */
 
 import { asyncStyle, apiWrapper, encodeInclude, encodeFilter } from "../common/functions";
-import { ConnectionOptions, CallbackFn, ListOptions } from "../common/interfaces";
+import { CallbackFn, ListOptions } from "../common/interfaces";
 import { ListResponse } from "../common/listResponse";
 import { AddFirmwareImageObject, AddFirmwareManifestObject, AddCampaignObject, UpdateCampaignObject, FirmwareImageListOptions, FirmwareManifestListOptions, CampaignListOptions } from "./types";
 import { FirmwareImage } from "./models/firmwareImage";
@@ -30,6 +30,7 @@ import { CampaignDeviceStateAdapter } from "./models/campaignDeviceStateAdapter"
 import { Endpoints } from "./endpoints";
 import { Filters } from "./filters";
 import { ApiMetadata } from "../common/apiMetadata";
+import { ConfigOptions } from "../../common/config";
 
 /**
  * ## Update API
@@ -75,7 +76,7 @@ export class UpdateApi {
     /**
      * @param options connection options
      */
-    constructor(options: ConnectionOptions) {
+    constructor(options: ConfigOptions) {
         this._endpoints = new Endpoints(options);
     }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,4 @@
-import { Config } from "./common/config";
+import { Config, ConfigOptions } from "./common/config";
 import { Factory } from "./foundation";
 import { Client } from "./client/client";
 
@@ -26,7 +26,7 @@ export class SDK {
      * @param config The configuration
      * @param client The client instance
      */
-    constructor(config?: Config, client?: Client) {
+    constructor(config?: ConfigOptions, client?: Client) {
         if (config && config instanceof Config) {
             this.config = config;
         } else {

--- a/test/integration/cache/moduleInstanceCache.ts
+++ b/test/integration/cache/moduleInstanceCache.ts
@@ -2,8 +2,8 @@ import { Cache } from "./cache";
 import { ServerError } from "../server/error";
 import * as PelionDMSDK from "../../../src";
 import { reverseMapModule, mapModule } from "../mapping/argumentMapping";
-import { ConnectionOptions } from "../../../src/legacy/common/interfaces";
 import { ModuleInstance } from "../instance/moduleInstance";
+import { ConfigOptions } from "../../../src/common/config";
 
 export class ModuleInstanceCache extends Cache<ModuleInstance> {
     private moduleList: Array<string>;
@@ -20,7 +20,7 @@ export class ModuleInstanceCache extends Cache<ModuleInstance> {
         return instance;
     }
 
-    public createModuleInstance(module: string, config: ConnectionOptions): ModuleInstance {
+    public createModuleInstance(module: string, config: ConfigOptions): ModuleInstance {
         const instance: ModuleInstance = new ModuleInstance(module, config);
         if (!instance.isValid()) {
             throw new ServerError(500, `Instance ("${instance.id}") of module ["${instance.sdkModule}"] cannot be stored, as invalid`);

--- a/test/integration/instance/moduleInstance.ts
+++ b/test/integration/instance/moduleInstance.ts
@@ -1,5 +1,4 @@
 import { Instance } from "./instance";
-import { ConnectionOptions } from "../../../src/legacy/common/interfaces";
 import { mapModule, mapMethod } from "../mapping/argumentMapping";
 import { SdkModule, SuccessCallback, ErrorCallback } from "../types";
 import { TestStubApi } from "../test/testStub";
@@ -7,12 +6,13 @@ import * as PelionDMSDK from "../../../src";
 import { SdkApi } from "../mapping/sdkMethod";
 import { ServerError } from "../server/error";
 import { ModuleDescription } from "../server/api/serverMessages";
+import { ConfigOptions } from "../../../src/common/config";
 
 export class ModuleInstance extends Instance<any> {
 
     public sdkModule: SdkModule;
 
-    constructor(pythonName: string, config: ConnectionOptions) {
+    constructor(pythonName: string, config: ConfigOptions) {
         const name: string = pythonName ? mapModule(pythonName) : "";
         const constructor = name === "TestStubApi" ? TestStubApi : (PelionDMSDK as any)[name];
         super(new constructor(config));

--- a/test/integration/server/api/apiModules.ts
+++ b/test/integration/server/api/apiModules.ts
@@ -1,9 +1,9 @@
 import { logMessage } from "../../logger";
 import { sendException, determineInstanceConfig } from "../utilities";
 import { ServerError } from "../error";
-import { ConnectionOptions } from "../../../../src/legacy/common/interfaces";
 import { ModuleInstanceCache } from "../../cache/moduleInstanceCache";
 import { ModuleInstance } from "../../instance/moduleInstance";
+import { ConfigOptions } from "../../../../src/common/config";
 
 const moduleIdParam: string = "moduleId";
 
@@ -16,7 +16,7 @@ export const apiModules = (app, instanceCache: ModuleInstanceCache) => {
     app.post("/modules/:moduleId/instances", (req, res, _next) => {
         const moduleId: string | undefined = req.params[moduleIdParam];
         logMessage(`Creating a module ("${moduleId}") instance`);
-        const config: ConnectionOptions = determineInstanceConfig(req.body);
+        const config: ConfigOptions = determineInstanceConfig(req.body);
         if (!moduleId) {
             sendException(res, new ServerError(400, "The module id has not been specified"));
             return;

--- a/test/integration/server/utilities.ts
+++ b/test/integration/server/utilities.ts
@@ -1,10 +1,10 @@
 import { logMessage } from "../logger";
-import { ConnectionOptions } from "../../../src/legacy/common/interfaces";
 import { TestError } from "./api/serverMessages";
 import { ServerError } from "./error";
 import { Exception } from "../types";
 import { RunnerConnectionOptions } from "./types";
 import { SDKError } from "../../../src/legacy/common/sdkError";
+import { ConfigOptions } from "../../../src/common/config";
 
 export const sendException = (res: any, exception: Exception): void => {
     let exceptionCode: number = 500;
@@ -35,12 +35,12 @@ export const sendSDKError = (res: any, error: SDKError): void => {
     }
 };
 
-export const determineInstanceConfig = (config: RunnerConnectionOptions): ConnectionOptions => {
+export const determineInstanceConfig = (config: RunnerConnectionOptions): ConfigOptions => {
     const apiKeyEnv: string = "MBED_CLOUD_SDK_API_KEY";
     const hostEnv: string = "MBED_CLOUD_SDK_HOST";
 
     // Environment configuration
-    const defaultConfig: ConnectionOptions = {
+    const defaultConfig: ConfigOptions = {
         apiKey: process.env[apiKeyEnv],
         host: process.env[hostEnv]
     };
@@ -55,7 +55,7 @@ export const determineInstanceConfig = (config: RunnerConnectionOptions): Connec
         logMessage(`The test server could not interpret instance configuration properly: [${configStr}]. Defaulting to test server configuration.`);
         return defaultConfig;
     }
-    const instanceConfig: ConnectionOptions = { ...defaultConfig, apiKey: config.api_key, host: config.host };
+    const instanceConfig: ConfigOptions = { ...defaultConfig, apiKey: config.api_key, host: config.host };
     return instanceConfig;
 };
 

--- a/test/integration/test/testStub.ts
+++ b/test/integration/test/testStub.ts
@@ -1,15 +1,15 @@
 import { SDKError } from "../../../src/legacy/common/sdkError";
 import { ServerError } from "../server/error";
-import { ConnectionOptions } from "../../../src/legacy/common/interfaces";
+import { ConfigOptions } from "../../../src/common/config";
 
 export class TestStubApi {
 
-    public options: ConnectionOptions | undefined;
+    public options: ConfigOptions | undefined;
 
     /**
      * @param options connection options
      */
-    constructor(options: ConnectionOptions | undefined) {
+    constructor(options: ConfigOptions | undefined) {
         this.options = options;
 
     }

--- a/test/unit/foundation/paginator.ts
+++ b/test/unit/foundation/paginator.ts
@@ -76,8 +76,9 @@ describe("test paginator", () => {
         expect(paginator.pageSize).toBe(50);
         expect(paginator.totalPages).toBe(1);
         expect(paginator.currentPageIndex).toBe(-1);
-        expect(paginator.currentPage).toBeUndefined();
+        expect(paginator.currentPage).toBeNull();
         expect(paginator.afters).toEqual([]);
+        expect(paginator.currentTotalCount).toBe(0);
     });
 
     it("should fetch one page", async () => {
@@ -94,6 +95,7 @@ describe("test paginator", () => {
 
         expect(page).not.toBeUndefined();
         expect(await paginator.totalCount()).toBe(12);
+        expect(paginator.currentTotalCount).toBe(12);
         checkPage(page, paginator, "AAAC", 0);
 
         expect(paginator.hasNextPage()).toBeTruthy();
@@ -153,7 +155,7 @@ describe("test paginator", () => {
         paginator.reset();
 
         expect(paginator.currentPageIndex).toBe(-1);
-        expect(paginator.currentPage).toBeUndefined();
+        expect(paginator.currentPage).toBeNull();
         expect(paginator.afters).toEqual([]);
         expect(paginator.listOptions.after).toBeNull();
     });

--- a/test/unit/foundation/singleEntryPoint.ts
+++ b/test/unit/foundation/singleEntryPoint.ts
@@ -38,13 +38,28 @@ describe("singleEntryPoint", () => {
         let count = 0;
         const sdk = new SDK(new Config({ apiKey: () => `ak_1_arrow_${count++}` }));
         expect("Bearer ak_1_arrow_0").toEqual(sdk.config.apiKey);
+        expect("Bearer ak_1_arrow_1").toEqual(sdk.config.apiKey);
 
         const user = sdk.foundation().userRepository();
 
-        expect("Bearer ak_1_arrow_1").toEqual(user.config.apiKey);
         expect("Bearer ak_1_arrow_2").toEqual(user.config.apiKey);
         expect("Bearer ak_1_arrow_3").toEqual(user.config.apiKey);
+        expect("Bearer ak_1_arrow_4").toEqual(user.config.apiKey);
     });
+
+    test("config with incrementing callback for key with interface", () => {
+        let count = 0;
+        const sdk = new SDK({ apiKey: () => `ak_1_arrow_${count++}` });
+        expect("Bearer ak_1_arrow_0").toEqual(sdk.config.apiKey);
+        expect("Bearer ak_1_arrow_1").toEqual(sdk.config.apiKey);
+
+        const user = sdk.foundation().userRepository();
+
+        expect("Bearer ak_1_arrow_2").toEqual(user.config.apiKey);
+        expect("Bearer ak_1_arrow_3").toEqual(user.config.apiKey);
+        expect("Bearer ak_1_arrow_4").toEqual(user.config.apiKey);
+    });
+
 
     test("multiple sdk instances", () => {
         const sdk1 = new SDK(new Config({ apiKey: "ak_1" }));

--- a/test/unit/foundation/singleEntryPoint.ts
+++ b/test/unit/foundation/singleEntryPoint.ts
@@ -25,6 +25,27 @@ describe("singleEntryPoint", () => {
         expect("Bearer ak_1").toEqual(user.config.apiKey);
     });
 
+    test("config with callback for key", () => {
+        const sdk = new SDK(new Config({ apiKey: () => "ak_1_arrow" }));
+        expect("Bearer ak_1_arrow").toEqual(sdk.config.apiKey);
+
+        const user = sdk.foundation().userRepository();
+
+        expect("Bearer ak_1_arrow").toEqual(user.config.apiKey);
+    });
+
+    test("config with incrementing callback for key", () => {
+        let count = 0;
+        const sdk = new SDK(new Config({ apiKey: () => `ak_1_arrow_${count++}` }));
+        expect("Bearer ak_1_arrow_0").toEqual(sdk.config.apiKey);
+
+        const user = sdk.foundation().userRepository();
+
+        expect("Bearer ak_1_arrow_1").toEqual(user.config.apiKey);
+        expect("Bearer ak_1_arrow_2").toEqual(user.config.apiKey);
+        expect("Bearer ak_1_arrow_3").toEqual(user.config.apiKey);
+    });
+
     test("multiple sdk instances", () => {
         const sdk1 = new SDK(new Config({ apiKey: "ak_1" }));
         expect("Bearer ak_1").toEqual(sdk1.config.apiKey);


### PR DESCRIPTION
Add option to pass callback as apiKey for scenarios where the user has to periodically refresh the key on the same instance. String remains a valid value.